### PR TITLE
Create SARIF report for checkReadme task

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,14 +28,21 @@ jobs:
         uses: gradle/actions/setup-gradle@v6
       - name: Run Build with Gradle Wrapper
         run: ./gradlew build --console=plain
-      - name: Upload test report
+      - name: Upload Test Report
         uses: actions/upload-artifact@v7
         if: ${{ failure() && hashFiles('build/reports/tests/test/index.html') != '' }}
         with:
           name: test-report
           path: build/reports/tests/test/
-      - name: Upload SARIF
+      - name: Upload Detekt SARIF Report
         uses: github/codeql-action/upload-sarif@v4
         if: ${{ (success() || failure()) && hashFiles('build/reports/detekt/detekt.sarif') != '' }}
         with:
           sarif_file: build/reports/detekt/detekt.sarif
+          category: detekt
+      - name: Upload Plugin SARIF Report
+        uses: github/codeql-action/upload-sarif@v4
+        if: ${{ (success() || failure()) && hashFiles('build/reports/fabrikt-gradle-plugin/report.sarif') != '' }}
+        with:
+          sarif_file: build/reports/fabrikt-gradle-plugin/report.sarif
+          category: fabrikt-gradle-plugin

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(libs.fabrikt)
     implementation(libs.kotlinpoet)
     implementation(libs.bundles.jackson)
+    implementation(libs.sarif4k)
     detektPlugins(libs.detekt.formatting)
 }
 

--- a/buildSrc/src/main/kotlin/ch/acanda/gradle/fabrikt/build/CheckReadmeTask.kt
+++ b/buildSrc/src/main/kotlin/ch/acanda/gradle/fabrikt/build/CheckReadmeTask.kt
@@ -1,21 +1,38 @@
 package ch.acanda.gradle.fabrikt.build
 
 import ch.acanda.gradle.fabrikt.build.builder.isNested
+import ch.acanda.gradle.fabrikt.build.sarif.SarifReport
 import ch.acanda.gradle.fabrikt.build.schema.ConfigurationSchema
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.github.detekt.sarif4k.ArtifactLocation
+import io.github.detekt.sarif4k.Level
+import io.github.detekt.sarif4k.Location
+import io.github.detekt.sarif4k.Message
+import io.github.detekt.sarif4k.MultiformatMessageString
+import io.github.detekt.sarif4k.PhysicalLocation
+import io.github.detekt.sarif4k.PropertyBag
+import io.github.detekt.sarif4k.Region
+import io.github.detekt.sarif4k.ReportingConfiguration
+import io.github.detekt.sarif4k.ReportingDescriptor
+import io.github.detekt.sarif4k.Result
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.VerificationException
+import org.gradle.api.tasks.VerificationTask
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import java.io.File
 
-abstract class CheckReadmeTask : DefaultTask() {
+@CacheableTask
+abstract class CheckReadmeTask : DefaultTask(), VerificationTask {
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -25,17 +42,22 @@ abstract class CheckReadmeTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     abstract val readme: RegularFileProperty
 
+    @get:OutputFile
+    abstract val sarif: RegularFileProperty
+
     init {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
         description = "Checks that all properties are documented in README.md."
         readme.convention(project.layout.projectDirectory.file("README.md"))
+        sarif.convention(project.layout.buildDirectory.file("reports/fabrikt-gradle-plugin/report.sarif"))
     }
 
     @TaskAction
     fun performCheck() {
         val schema: ConfigurationSchema =
             ObjectMapper(YAMLFactory()).registerKotlinModule().readValue(schema.get().asFile)
-        val readme = readme.get().asFile.readText()
+        val readmeFile = readme.get().asFile
+        val readme = readmeFile.readText()
 
         val undocumentedProperties =
             schema.configurations
@@ -46,6 +68,8 @@ abstract class CheckReadmeTask : DefaultTask() {
                 }
                 .filter { property -> !readme.contains("| $property ") }
                 .toList();
+
+        createSarifReport(readmeFile, readme, undocumentedProperties)
 
         if (!undocumentedProperties.isEmpty()) {
             val msg = if (undocumentedProperties.size == 1) {
@@ -58,6 +82,68 @@ abstract class CheckReadmeTask : DefaultTask() {
             logger.error(msg)
             throw VerificationException(msg)
         }
+    }
+
+    private fun createSarifReport(
+        readmeFile: File,
+        readme: String,
+        undocumentedProperties: List<String>
+    ) {
+        val report = SarifReport(
+            toolName = "fabrikt-gradle-plugin",
+            rules = buildRules(),
+            results = undocumentedProperties.map { property ->
+                Result(
+                    ruleID = "UndocumentedProperty",
+                    message = Message(
+                        text = "The property $property is not documented in README.md.",
+                        markdown = "The property `$property` is not documented in README.md."
+                    ),
+                    locations = listOf(
+                        Location(
+                            physicalLocation = PhysicalLocation(
+                                artifactLocation = ArtifactLocation(uri = readmeFile.toURI().toString()),
+                                region = buildRegion(readme, property)
+                            )
+                        )
+                    ),
+                    partialFingerprints = mapOf("property" to property)
+                )
+            },
+        )
+        report.writeTo(sarif.asFile.get().toPath())
+    }
+
+    private fun buildRules(): List<ReportingDescriptor> = listOf(
+        ReportingDescriptor(
+            id = "UndocumentedProperty",
+            shortDescription = MultiformatMessageString(text = "A property is not documented in README.md."),
+            defaultConfiguration = ReportingConfiguration(level = Level.Error),
+            help = MultiformatMessageString(text = "Document the property in README.md in the table of the section \"Configuration\"."),
+            properties = PropertyBag(tags = setOf("documentation"), map = emptyMap())
+        )
+    )
+
+    private fun buildRegion(readme: String, property: String): Region {
+        val table = readme.lineSequence()
+            .mapIndexed { index, line -> (index + 1) to line }
+            .dropWhile { (_, line) -> line != "## Configuration" }
+            .dropWhile { (_, line) -> !line.startsWith("|-") }
+            .drop(1)
+            .takeWhile { (_, line) -> line.startsWith("| ") }
+            .toList()
+        var startLine = table.first().first
+        var endLine = table.last().first
+        if (property.contains('.')) {
+            val prefix = property.substringBeforeLast('.')
+            val startsWithPrefix: (Pair<Int, String>) -> Boolean = { (_, line) -> line.startsWith("| $prefix.") }
+            table.firstOrNull(startsWithPrefix)?.let { startLine = it.first }
+            table.lastOrNull(startsWithPrefix)?.let { endLine = it.first }
+        }
+        return Region(
+            startLine = startLine.toLong(),
+            endLine = endLine.toLong(),
+        )
     }
 
     private companion object {

--- a/buildSrc/src/main/kotlin/ch/acanda/gradle/fabrikt/build/sarif/SarifReport.kt
+++ b/buildSrc/src/main/kotlin/ch/acanda/gradle/fabrikt/build/sarif/SarifReport.kt
@@ -1,0 +1,41 @@
+package ch.acanda.gradle.fabrikt.build.sarif
+
+import io.github.detekt.sarif4k.ReportingDescriptor
+import io.github.detekt.sarif4k.Result
+import io.github.detekt.sarif4k.Run
+import io.github.detekt.sarif4k.SarifSchema210
+import io.github.detekt.sarif4k.Tool
+import io.github.detekt.sarif4k.ToolComponent
+import io.github.detekt.sarif4k.Version
+import kotlinx.serialization.json.Json
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+public class SarifReport(
+    private val toolName: String,
+    private val rules: List<ReportingDescriptor> = emptyList(),
+    private val results: List<Result>,
+) {
+
+    fun writeTo(file: Path) {
+        file.writeText(Json.encodeToString(buildSarif()))
+    }
+
+    private fun buildSarif() = SarifSchema210(
+        schema = "http://json.schemastore.org/sarif-2.1.0",
+        version = Version.The210,
+        runs = buildRuns()
+    )
+
+    private fun buildRuns() = listOf(
+        Run(
+            tool = buildTool(),
+            results = results
+        )
+    )
+
+    private fun buildTool() = Tool(
+        driver = ToolComponent(name = toolName, rules = rules),
+    )
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name = "
 kotest-runner-junit5 = { group = "io.kotest", name = "kotest-runner-junit5", version.ref = "kotest" }
 kotest-property = { group = "io.kotest", name = "kotest-property", version.ref = "kotest" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version = "6.1.2" }
+sarif4k = { group = "io.github.detekt.sarif4k", name = "sarif4k", version = "0.7.0" }
 
 [bundles]
 jackson = ["jackson-module-kotlin", "jackson-dataformat-yaml"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration checks now always generate a SARIF report for undocumented README properties, including precise table-based location references.
  * CI now also produces an additional SARIF report for the plugin’s validation results.
* **Documentation**
  * Updated the Gradle plugin configuration property reference to reflect renamed entries.
* **CI Improvements**
  * Refined static-analysis report uploads, including improved SARIF categorization and an added, existence-gated upload for the plugin SARIF output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->